### PR TITLE
make `generate-manifest` more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM emscripten/emsdk:3.1.51
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config \
+    jq pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build/umineko-web

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -9,8 +9,16 @@ fi
 
 echo "Generating asset manifest..."
 
+if command -v jq >/dev/null 2>&1; then
+  DIRS="$(find "$GAME_DIR" -mindepth 1 -type d -printf '%P\0' | sort -z | jq -Rsc 'split("\u0000")[:-1]')"
+  FILES="$(find "$GAME_DIR" -mindepth 1 -type f -printf '%P\0' | sort -z | jq -Rsc 'split("\u0000")[:-1]')"
+  jq -cn --argjson dirs "$DIRS" --argjson files "$FILES" '{dirs:$dirs,files:$files}' > "$MANIFEST"
+  echo "Manifest generated: $(jq -r 'length' <<<"$FILES") files in $(jq -r 'length' <<<"$DIRS") directories"
+  exit 0
+fi
+
 printf '{"dirs":[' > "$MANIFEST"
-find "$GAME_DIR" -type d | sed "s|$GAME_DIR||" | grep -v '^$' | sort | awk '
+find "$GAME_DIR" -type d | sed "s|$GAME_DIR/||" | grep -v '^$' | sort | awk '
     BEGIN { first = 1 }
     {
         gsub(/\\/, "\\\\")
@@ -22,7 +30,7 @@ find "$GAME_DIR" -type d | sed "s|$GAME_DIR||" | grep -v '^$' | sort | awk '
 ' >> "$MANIFEST"
 
 printf '],"files":[' >> "$MANIFEST"
-find "$GAME_DIR" -type f | sed "s|$GAME_DIR||" | sort | awk '
+find "$GAME_DIR" -type f | sed "s|$GAME_DIR/||" | sort | awk '
     BEGIN { first = 1 }
     {
         gsub(/\\/, "\\\\")

--- a/web/index.html
+++ b/web/index.html
@@ -97,7 +97,7 @@
 
                 for (let i = 0; i < dirs.length; i++) {
                     try {
-                        FS.mkdirTree('/game' + dirs[i]);
+                        FS.mkdirTree('/game/' + dirs[i]);
                     } catch (e) {}
                 }
 
@@ -106,10 +106,10 @@
 
                 for (let i = 0; i < files.length; i++) {
                     const filePath = files[i];
-                    const vfsPath = '/game' + filePath;
+                    const vfsPath = '/game/' + filePath;
 
                     if (shouldEagerLoad(filePath)) {
-                        eagerFetch(vfsPath, '/game' + filePath);
+                        eagerFetch(vfsPath, '/game/' + filePath);
                         eagerCount++;
                     } else {
                         try {


### PR DESCRIPTION
`generate-manifest.sh` produces invalid json depending on the filenames (in my case, this happened with non-latin characters on f2fs, after copying files from windows installation without proper nls support).
Let's make it more robust by using good old jq (and while we're at it, use `\0`-separated list rather than`\n`-separated).
After this change, everything loaded successfully
![umi](https://github.com/user-attachments/assets/cfc9f356-5186-478c-a4af-a0b943c9772c)

Also removing leading `/` from the paths (somewhat helpful, given that `manifest.json` has more than 1e5 entries).
Leaving the original awk-based code just in case if it might still be needed for manual refreshing outside of the container.