### PR TITLE
make asset optimization nicer

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 /usr/local/bin/generate-manifest.sh
-/usr/local/bin/convert-assets.sh /usr/share/nginx/html/game /usr/share/nginx/html/cache/game &
+nice -n 19 ionice -c 3 -n 7 /usr/local/bin/convert-assets.sh /usr/share/nginx/html/game /usr/share/nginx/html/cache/game &
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
`convert-assets` is quite long and resource-intensive background process, it would be nice and ionice if it had appropriate priority.

On a side note, imho optimization should be a bit more configurable: lossy compression has almost no meaning if it's played locally or within local 10Gbps+ network, and the number of jobs should depend on number of available processors and/or instance-specific parameters. Ideally compression types/levels should be adjustable as well.
Not sure about the implementation though; i'd simply slap a bunch of env variables for that, but the proper solution is probably to move optimization to separate `service` and use docker compose profiles.