### PR TITLE
add support for `.hau` files in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,12 @@ server {
     listen 80;
     server_name _;
 
+    include mime.types;
+    default_type  application/octet-stream;
+    types {
+        text/plain cfg;
+    }
+
     root /usr/share/nginx/html;
     index index.html;
 
@@ -12,6 +18,16 @@ server {
     location / {
         add_header Cache-Control "no-cache";
         try_files $uri $uri/ =404;
+    }
+
+    location ~ ^/game/(backgrounds|graphics)/(.+)\.hau$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files /cache/game/$1/$2.webp /game/$1/$2.png =404;
+    }
+
+    location ~ ^/game/video/(.+)\.hau$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files /cache/game/video/$1.webm /game/video/$1.mp4 =404;
     }
 
     location /game/ {
@@ -26,9 +42,6 @@ server {
     }
 
     location ~* \.(wasm|js)$ {
-        types {
-            application/wasm wasm;
-        }
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
     }


### PR DESCRIPTION
This PR fixes `Content-Type` header for most requests, and add support for `.hau` files that automatically resolve to compressed or original file on server side, allowing to avoid unnecessary web requests and cache pollution on client side.
Setting as draft because ideally this should come with client-side counterpart (i'll open and link PR against https://github.com/VictoriqueMoe/onscripter-ru-wasm once it's ready).

Assuming `location /game/ { }` block is needed only for `ogg` files after this, it can be made more specific. I'm not 100% sure yet that this is the case.